### PR TITLE
Suppress successful putval responses to exec plugin

### DIFF
--- a/src/utils_cmd_putval.c
+++ b/src/utils_cmd_putval.c
@@ -218,7 +218,8 @@ int handle_putval (FILE *fh, char *buffer)
 	} /* while (*buffer != 0) */
 	/* Done parsing the options. */
 
-	print_to_socket (fh, "0 Success: %i %s been dispatched.\n",
+    if (fh!=stdout)
+	    print_to_socket (fh, "0 Success: %i %s been dispatched.\n",
 			values_submitted,
 			(values_submitted == 1) ? "value has" : "values have");
 


### PR DESCRIPTION
exec plugins are never supposed to receive responses
to putval commands. These responses are instead sent
to STDOUT, which is often attached to /dev/null.
Newer init systems, such as systemd, instead log
these responses.

This patch preserves the expected behavior by suppressing
the response if and only if the destination is STDOUT.

(cherry picked from commit 53de2cf4354da65843104ea430d6fdf0375a0c64)